### PR TITLE
Implement execution of prepared statements

### DIFF
--- a/Sources/Rope.swift
+++ b/Sources/Rope.swift
@@ -86,6 +86,26 @@ public final class Rope {
         return try execQuery(statement: statement, params: params)
     }
 
+    public func executePreparedStatement(named name: String, params: Any...) throws -> RopeResult {
+        let (paramValues, length) = createParamValuesForLibpq(params: params)
+        defer {
+            paramValues.deallocate(capacity: length)
+        }
+        let result = PQexecPrepared(
+            self.conn,
+            name,
+            Int32(params.count),
+            paramValues,
+            nil,    // "The array pointer can be null when there are no binary parameters."
+            nil,    // "If the array pointer is null then all parameters are presumed to be text strings."
+            0       // "Specify zero to obtain results in text format"
+        )
+        guard let res = result else {
+            throw failWithError()
+        }
+        return try validateQueryResultStatus(res)
+    }
+
     private func execQuery(statement: String, params: [Any]? = nil) throws -> RopeResult {
         if statement.isEmpty {
             throw RopeError.emptyQuery
@@ -103,21 +123,9 @@ public final class Rope {
             return try validateQueryResultStatus(res)
         }
 
-        let paramsCount = params.count
-        let values = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: paramsCount)
-
+        let (values, count) = createParamValuesForLibpq(params: params)
         defer {
-            values.deinitialize(count: paramsCount)
-            values.deallocate(capacity: paramsCount)
-        }
-
-        var tempValues = [Array<UInt8>]()
-        for (idx, value) in params.enumerated() {
-
-            let s = String(describing: value).utf8
-
-            tempValues.append(Array<UInt8>(s) + [0])
-            values[idx] = UnsafePointer<Int8>(OpaquePointer(tempValues.last!))
+            values.deallocate(capacity: count)
         }
         let result = self.connectionQueue.sync {
             return PQexecParams(self.conn, statement, Int32(params.count), nil, values, nil, nil, Int32(0))
@@ -127,6 +135,21 @@ public final class Rope {
         }
 
         return try validateQueryResultStatus(res)
+    }
+
+    private func createParamValuesForLibpq(params: [Any]) -> (paramValues: UnsafeMutablePointer<UnsafePointer<Int8>?>, length: Int) {
+        let paramsCount = params.count
+        let values = UnsafeMutablePointer<UnsafePointer<Int8>?>.allocate(capacity: paramsCount)
+
+        var tempValues = [Array<UInt8>]()
+        for (idx, value) in params.enumerated() {
+
+            let s = String(describing: value).utf8
+
+            tempValues.append(Array<UInt8>(s) + [0])
+            values[idx] = UnsafePointer<Int8>(OpaquePointer(tempValues.last!))
+        }
+        return (values, paramsCount)
     }
 
     func validateQueryResultStatus(_ res: OpaquePointer) throws -> RopeResult {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,13 +1,21 @@
 // Generated using Sourcery 0.5.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
+// LinuxMain.stencil is a template ripped from Sourcery's main codebase that autogenerates the XCTMain call for us!
 import XCTest
 @testable import RopeTests
 
 extension RopeConnectionTests {
   static var allTests = [
     ("testConnectWithParams", testConnectWithParams),
-    ("testConnectWithStruct", testConnectWithStruct)
+    ("testConnectWithStruct", testConnectWithStruct),
+  ]
+}
+
+extension RopeQueryJSONTests {
+  static var allTests = [
+    ("testQueryInsertStatement", testQueryInsertStatement),
+    ("testQuerySelectStatement", testQuerySelectStatement),
   ]
 }
 
@@ -20,18 +28,14 @@ extension RopeQueryTests {
     ("testReadmeExample", testReadmeExample),
     ("testQuerySelectRowStringTypes", testQuerySelectRowStringTypes),
     ("testQuerySelectRowNumericTypes", testQuerySelectRowNumericTypes),
-    ("testQuerySelectRowDateTypes", testQuerySelectRowDateTypes)
+    ("testQuerySelectRowDateTypes", testQuerySelectRowDateTypes),
+    ("testPreparedStatement", testPreparedStatement),
   ]
 }
 
-extension RopeQueryJSONTests {
-  static var allTests = [
-    ("testQueryInsertStatement", testQueryInsertStatement)
-  ]
-}
 
 XCTMain([
   testCase(RopeConnectionTests.allTests),
+  testCase(RopeQueryJSONTests.allTests),
   testCase(RopeQueryTests.allTests),
-  testCase(RopeQueryJSONTests.allTests)
 ])

--- a/Tests/RopeTests/RopeQueryTests.swift
+++ b/Tests/RopeTests/RopeQueryTests.swift
@@ -230,7 +230,6 @@ final class RopeQueryTests: XCTestCase {
         // Test it out
         let result = try? conn!.executePreparedStatement(named: "my_special_query", params: "1984")
         let id = result?.rows().first?["id"] as? Int
-        dump(result?.rows())
         XCTAssertEqual(id, 30)
 
     }

--- a/Tests/RopeTests/RopeQueryTests.swift
+++ b/Tests/RopeTests/RopeQueryTests.swift
@@ -220,6 +220,21 @@ final class RopeQueryTests: XCTestCase {
         XCTAssertNil(idx)
     }
 
+    func testPreparedStatement() {
+        // Set up
+        _ = try! conn!.query("CREATE TEMPORARY TABLE prepared_statement_table(id integer PRIMARY KEY, title text)")
+        _ = try! conn!.query("INSERT INTO prepared_statement_table(id, title) VALUES(20,'War And Peace'),(30,'1984'),(40,'Fahrenheit 951')")
+        // Prepare it baby!
+        _ = try! conn!.query("PREPARE my_special_query(text) AS SELECT id FROM prepared_statement_table WHERE title = $1")
+
+        // Test it out
+        let result = try? conn!.executePreparedStatement(named: "my_special_query", params: "1984")
+        let id = result?.rows().first?["id"] as? Int
+        dump(result?.rows())
+        XCTAssertEqual(id, 30)
+
+    }
+
     /// helper function which tests the connection and
     /// inserts two rows to test defaults & type conversion
     /// returns the optional rows, nil on error


### PR DESCRIPTION
Since libpq doesn't support the execute command, for some weird reason...

closes #54 